### PR TITLE
upgrade external-secrets to v0.17.0 (api/v1)

### DIFF
--- a/charts/simple/Chart.yaml
+++ b/charts/simple/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: simple
 description: Metachart born Helm Chart
 type: application
-version: "0.1.5"
+version: "0.2.0"
 appVersion: none

--- a/charts/simple/config/resources.yaml
+++ b/charts/simple/config/resources.yaml
@@ -147,23 +147,23 @@ resources:
     kind: PriorityClass
     jsonSchemaRef: metachart.api.io.k8s.api.scheduling.v1.PriorityClass
 
-  #: external-secrets.io/v1beta1
+  #: external-secrets.io/v1
   externalsecrets:
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: ExternalSecret
-    jsonSchemaRef: metachart.api.io.external-secrets.apis.externalsecrets.v1beta1.ExternalSecret
+    jsonSchemaRef: metachart.api.io.external-secrets.apis.externalsecrets.v1.ExternalSecret
   clusterexternalsecrets:
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: ClusterExternalSecret
-    jsonSchemaRef: metachart.api.io.external-secrets.apis.externalsecrets.v1beta1.ClusterExternalSecret
+    jsonSchemaRef: metachart.api.io.external-secrets.apis.externalsecrets.v1.ClusterExternalSecret
   secretstores:
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: SecretStore
-    jsonSchemaRef: metachart.api.io.external-secrets.apis.externalsecrets.v1beta1.SecretStore
+    jsonSchemaRef: metachart.api.io.external-secrets.apis.externalsecrets.v1.SecretStore
   clustersecretstores:
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: ClusterSecretStore
-    jsonSchemaRef: metachart.api.io.external-secrets.apis.externalsecrets.v1beta1.ClusterSecretStore
+    jsonSchemaRef: metachart.api.io.external-secrets.apis.externalsecrets.v1.ClusterSecretStore
 
   #: monitoring.coreos.com/v1alpha1
   alertmanagerconfigs:

--- a/charts/simple/config/schema.yaml
+++ b/charts/simple/config/schema.yaml
@@ -241,18 +241,18 @@ rules:
     source: io.k8s.api.scheduling.v1.PriorityClass
     <<: *defaultRootKey
 
-  #: external-secrets.io/v1beta1
-  - target: metachart.api.io.external-secrets.apis.externalsecrets.v1beta1.ExternalSecret
-    source: io.external-secrets.apis.externalsecrets.v1beta1.ExternalSecret
+  #: external-secrets.io/v1
+  - target: metachart.api.io.external-secrets.apis.externalsecrets.v1.ExternalSecret
+    source: io.external-secrets.apis.externalsecrets.v1.ExternalSecret
     <<: *defaultRootKey
-  - target: metachart.api.io.external-secrets.apis.externalsecrets.v1beta1.ClusterExternalSecret
-    source: io.external-secrets.apis.externalsecrets.v1beta1.ClusterExternalSecret
+  - target: metachart.api.io.external-secrets.apis.externalsecrets.v1.ClusterExternalSecret
+    source: io.external-secrets.apis.externalsecrets.v1.ClusterExternalSecret
     <<: *defaultRootKey
-  - target: metachart.api.io.external-secrets.apis.externalsecrets.v1beta1.SecretStore
-    source: io.external-secrets.apis.externalsecrets.v1beta1.SecretStore
+  - target: metachart.api.io.external-secrets.apis.externalsecrets.v1.SecretStore
+    source: io.external-secrets.apis.externalsecrets.v1.SecretStore
     <<: *defaultRootKey
-  - target: metachart.api.io.external-secrets.apis.externalsecrets.v1beta1.ClusterSecretStore
-    source: io.external-secrets.apis.externalsecrets.v1beta1.ClusterSecretStore
+  - target: metachart.api.io.external-secrets.apis.externalsecrets.v1.ClusterSecretStore
+    source: io.external-secrets.apis.externalsecrets.v1.ClusterSecretStore
     <<: *defaultRootKey
 
   #: monitoring.coreos.com/v1alpha1

--- a/charts/simple/docs/resources.md
+++ b/charts/simple/docs/resources.md
@@ -62,7 +62,7 @@ A set of resources supported by the chart
 | certificatesigningrequests   | CertificateSigningRequest | - |
 
 
-## external-secrets.io/v1beta1
+## external-secrets.io/v1
 
 | Values file key | Kind | Preprocessor |
 | --------------- | ---- | ------------ |

--- a/charts/simple/templates/generated/_settings.tpl
+++ b/charts/simple/templates/generated/_settings.tpl
@@ -13,7 +13,7 @@ certificatesigningrequests:
   kindCamelCase: CertificateSigningRequest
   preprocess: false
 clusterexternalsecrets:
-  apiVersion: external-secrets.io/v1beta1
+  apiVersion: external-secrets.io/v1
   kindCamelCase: ClusterExternalSecret
   preprocess: false
 clusterrolebindings:
@@ -25,7 +25,7 @@ clusterroles:
   kindCamelCase: ClusterRole
   preprocess: false
 clustersecretstores:
-  apiVersion: external-secrets.io/v1beta1
+  apiVersion: external-secrets.io/v1
   kindCamelCase: ClusterSecretStore
   preprocess: false
 configmaps:
@@ -49,7 +49,7 @@ deployments:
   kindCamelCase: Deployment
   preprocess: true
 externalsecrets:
-  apiVersion: external-secrets.io/v1beta1
+  apiVersion: external-secrets.io/v1
   kindCamelCase: ExternalSecret
   preprocess: false
 horizontalpodautoscalers:
@@ -125,7 +125,7 @@ secrets:
   kindCamelCase: Secret
   preprocess: false
 secretstores:
-  apiVersion: external-secrets.io/v1beta1
+  apiVersion: external-secrets.io/v1
   kindCamelCase: SecretStore
   preprocess: false
 serviceaccounts:


### PR DESCRIPTION
In [v0.17.0 release](https://github.com/external-secrets/external-secrets/releases/tag/v0.17.0) of exteral-secrets `v1beta1` API got deprecated